### PR TITLE
Update rpi-rauc-aws.yml

### DIFF
--- a/conf/kas/rpi-rauc-aws.yml
+++ b/conf/kas/rpi-rauc-aws.yml
@@ -16,12 +16,12 @@ repos:
   meta-raspberry:
     url: https://github.com/agherzan/meta-raspberrypi
     path: layers/meta-raspberrypi
-    refspec: kirkstone
+    branch: kirkstone
 
   poky:
     url: https://git.yoctoproject.org/git/poky
     path: layers/poky
-    refspec: kirkstone
+    branch: kirkstone
     layers:
       meta:
       meta-poky:
@@ -30,7 +30,7 @@ repos:
   meta-openembedded:
     url: http://git.openembedded.org/meta-openembedded
     path: layers/meta-openembedded
-    refspec: kirkstone
+    branch: kirkstone
     layers:
       meta-oe:
       meta-python:
@@ -41,19 +41,19 @@ repos:
   meta-rauc:
     url: https://github.com/rauc/meta-rauc
     path: layers/meta-rauc
-    refspec: kirkstone
+    branch: kirkstone
  
   meta-rauc-community:
     url: https://github.com/Trellis-Logic/meta-rauc-community
     path: layers/meta-rauc-community
-    refspec: kirkstone+rpi-use-machine-var
+    branch: kirkstone+rpi-use-machine-var
     layers:
       meta-rauc-raspberrypi:
 
   meta-aws:
     url: https://github.com/aws4embeddedlinux/meta-aws.git
     path: layers/meta-aws
-    refspec: kirkstone-next
+    branch: kirkstone-next
 
 bblayers_conf_header:
   standard: |

--- a/conf/kas/rpi-rauc-aws.yml
+++ b/conf/kas/rpi-rauc-aws.yml
@@ -44,9 +44,9 @@ repos:
     branch: kirkstone
  
   meta-rauc-community:
-    url: https://github.com/Trellis-Logic/meta-rauc-community
+    url: https://github.com/rauc/meta-rauc-community
     path: layers/meta-rauc-community
-    branch: kirkstone+rpi-use-machine-var
+    branch: kirkstone
     layers:
       meta-rauc-raspberrypi:
 

--- a/conf/kas/rpi-rauc-aws.yml
+++ b/conf/kas/rpi-rauc-aws.yml
@@ -1,5 +1,5 @@
 header:
-  version: 8
+  version: 14
 
 machine: raspberrypi3
 distro: poky


### PR DESCRIPTION
Hi,

This GitHub pull request updates `rpi-rauc-aws.yml` with the following modifications:

* Replaces `refspec` with branch because the `refspec` is obsolete. Migrates the kas configuration to use `branch` instead.
* Updates configuration format from version 8 to version 14.
* Switches to branch kirkstone for meta-rauc-community as it now contains the commit to use MACHINE variable in the update bundle and system.conf.

Best regards, Leon